### PR TITLE
Use node slim because the resulting image is significantly smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:14-slim
 
 RUN mkdir /app
 RUN mkdir /serverless


### PR DESCRIPTION
On disk size now much smaller:

    aligent/serverless-slim                  latest              ab52e0019920        5 minutes ago       503MB
    aligent/serverless                       latest              dd558941414c        47 hours ago        1.24GB
