### PR TITLE
Added default .serverlessrc

### DIFF
--- a/.serverlessrc
+++ b/.serverlessrc
@@ -1,0 +1,3 @@
+{
+  "trackingDisabled": false,
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:15-alpine3.13
 
 COPY .serverlessrc /home/node/.serverlessrc
 RUN mkdir /app /serverless /home/node/.config /home/node/.serverless
-RUN chown node:node /app /serverless /home/node/.config /home/node/.serverless
+RUN chown node:node /app /serverless /home/node/.config /home/node/.serverless /home/node/.serverlessrc
 
 RUN apk update && \
     apk add \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:15-alpine3.13
 
+COPY .serverlessrc /home/node/.serverlessrc
 RUN mkdir /app /serverless /home/node/.config /home/node/.serverless
 RUN chown node:node /app /serverless /home/node/.config /home/node/.serverless
 

--- a/Dockerfile-offline
+++ b/Dockerfile-offline
@@ -1,7 +1,8 @@
 FROM node:15-buster-slim
 
+COPY .serverlessrc /home/node/.serverlessrc
 RUN mkdir /app /serverless /home/node/.config /home/node/.serverless
-RUN chown node:node /app /serverless /home/node/.config /home/node/.serverless
+RUN chown node:node /app /serverless /home/node/.config /home/node/.serverless /home/node/.serverlessrc
 RUN mkdir -p /usr/share/man/man1
 
 ARG DEBIAN_INTERACTIVE=noninteractive

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ useradd -g ${DOCKER_GID} --home-dir /home/node -s /bin/bash -u ${DOCKER_UID} nod
 
 chown -R node:node /home/node/.config
 chown -R node:node /home/node/.serverless
+chown -R node:node /home/node/.serverlessrc
 
 cd $APP_ROOT
 


### PR DESCRIPTION
Looks like serverless have added a config file, I was getting some errors after updating my localstack project since it could not create the file automatically in the node home directory. Added in a default file here and updated the entrypoint so it's owned by the correct user at startup.

https://www.serverless.com/framework/docs/providers/aws/cli-reference/slstats/