### PR TITLE
Remove trailing comma

### DIFF
--- a/.serverlessrc
+++ b/.serverlessrc
@@ -1,3 +1,3 @@
 {
-  "trackingDisabled": false,
+  "trackingDisabled": false
 }


### PR DESCRIPTION
Remove trailing comma causing invalid json error in serverless output