### PR TITLE
Update dockerfiles to node 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine3.13
+FROM node:16-alpine3.14
 
 COPY .serverlessrc /home/node/.serverlessrc
 RUN mkdir /app /serverless /home/node/.config /home/node/.serverless

--- a/Dockerfile-offline
+++ b/Dockerfile-offline
@@ -1,4 +1,4 @@
-FROM node:14-buster-slim
+FROM node:16-buster-slim
 
 COPY .serverlessrc /home/node/.serverlessrc
 RUN mkdir /app /serverless /home/node/.config /home/node/.serverless


### PR DESCRIPTION
This will flow into https://github.com/aligent/serverless-deploy-pipe which will allow node 16 to be used within serverless.