### PR TITLE
Lock node version to 16.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.14
+FROM node:16.11-alpine3.14
 
 COPY .serverlessrc /home/node/.serverlessrc
 RUN mkdir /app /serverless /home/node/.config /home/node/.serverless

--- a/Dockerfile-offline
+++ b/Dockerfile-offline
@@ -1,4 +1,4 @@
-FROM node:16-buster-slim
+FROM node:16.11-buster-slim
 
 COPY .serverlessrc /home/node/.serverlessrc
 RUN mkdir /app /serverless /home/node/.config /home/node/.serverless


### PR DESCRIPTION
This PR locks node to the same version as our serverless template (16.11) for constancy across all our serverless tooling and to ensure our pipelines work with the `engine-strict` changes made to that template.