### PR TITLE
Added chown for node:node to .aws and .npm folders

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,8 @@ useradd -g ${DOCKER_GID} --home-dir /home/node -s /bin/bash -u ${DOCKER_UID} nod
 chown -R node:node /home/node/.config
 chown -R node:node /home/node/.serverless
 chown -R node:node /home/node/.serverlessrc
+chown -R node:node /home/node/.aws
+chown -R node:node /home/node/.npm
 
 cd $APP_ROOT
 


### PR DESCRIPTION
If the `~/.npm` folder does not exist on the host machine, user will not able to perform `npm install`:

npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /home/node/.npm/_cacache
npm ERR! errno EACCES
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1062067112:1062000513 "/home/node/.npm"

The error message is not very useful as it report in the context of docker container. Instead of manually creating `~/.npm` on host machine, I think it's better to chown the folder.