### PR TITLE
Added "groff" & "less" as dependencies for awscli in alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN chown node:node /app /serverless /home/node/.config /home/node/.serverless /
 
 RUN apk update && \
     apk add \
-      sudo python3 py3-pip bash shadow make g++ &&  \
+      sudo python3 py3-pip bash shadow make g++ groff less &&  \
     pip3 --no-cache-dir install --upgrade awscli && \
     rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
I was unable to perform any `aws cli` command against our docker containers (both aligent/serverless:latest & aligent/serverless:offline)
Any `aws` command except `aws --version` returns with `Could not find executable named "groff"` error. This commit fix this issue by adding `groff` & `less` libraries. Similar issue & solution can be found from: https://github.com/aws/aws-cli/issues/1957#issuecomment-444307537