### PR TITLE
Add .azure folder to entry point file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ hub as [aligent/serverless](https://hub.docker.com/r/aligent/serverless).
 Add the following lines to your `~/.bashrc` file to be able to run it easily...
 
 ```
-alias node-run='docker run --rm -it --volume ~/.aws:/home/node/.aws --volume ~/.azure:/home/node/.azure --volume ~/.npm:/home/node/.npm --volume $PWD:/app aligent/serverless'
+alias node-run='docker run --rm -it --volume ~/.aws:/home/node/.aws --volume ~/.azure:/home/node/.azure --volume ~/.npm:/home/node/.npm --volume "$PWD:/app" aligent/serverless'
 alias serverless='node-run serverless'
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ hub as [aligent/serverless](https://hub.docker.com/r/aligent/serverless).
 
 ## Installation
 
-Ensure you have a .npm directory for caching dependancies (`mkdir -p ~/.npm`)
-
 Add the following lines to your `~/.bashrc` file to be able to run it easily...
 
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Ensure you have a .npm directory for caching dependancies (`mkdir -p ~/.npm`)
 Add the following lines to your `~/.bashrc` file to be able to run it easily...
 
 ```
-alias node-run='docker run --rm -it --volume ~/.aws:/home/node/.aws --volume ~/.npm:/home/node/.npm --volume $PWD:/app aligent/serverless'
+alias node-run='docker run --rm -it --volume ~/.aws:/home/node/.aws --volume ~/.azure:/home/node/.azure --volume ~/.npm:/home/node/.npm --volume $PWD:/app aligent/serverless'
 alias serverless='node-run serverless'
 ```
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,7 @@ chown -R node:node /home/node/.serverless
 chown -R node:node /home/node/.serverlessrc
 chown -R node:node /home/node/.aws
 chown -R node:node /home/node/.npm
+chown -R node:node /home/node/.azure
 
 cd $APP_ROOT
 


### PR DESCRIPTION
- Added /home/node/.azure folder to the list of `chown` folders for anyone who needs to work on serverless on Azure.
- Wrap `$PWD:\app` in double quote to fix issue with spacing in folder name resolved by `$PWD`

