### PR TITLE
Add symlink for serverless.js to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ WORKDIR /serverless
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin:/serverless/node_modules/serverless/bin/
-RUN echo 'alias serverless="serverless.js"' >> ~/.bashrc
 
 COPY --chown=node:node package.json ./
 COPY --chown=node:node package-lock.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /serverless
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin:/serverless/node_modules/serverless/bin/
+RUN echo 'alias serverless="serverless.js"' >> ~/.bashrc
 
 COPY --chown=node:node package.json ./
 COPY --chown=node:node package-lock.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY --chown=node:node package.json ./
 COPY --chown=node:node package-lock.json ./
 
 RUN npm ci && serverless.js --version
+RUN ln /serverless/node_modules/serverless/bin/serverless.js /serverless/node_modules/serverless/bin/serverless
 
 WORKDIR /app
 USER root


### PR DESCRIPTION
Adds a symlink for the serverless command. Serverless compose will try to call `serverless` not `serverless.js`. Therefore `serverless` needs to be a valid function.