### PR TITLE
Update node version to 16.19.0-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.19.0-alpine
+FROM node:16.19.0-alpine3.16
 
 COPY .serverlessrc /home/node/.serverlessrc
 RUN mkdir /app /serverless /home/node/.config /home/node/.serverless

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.11-alpine3.14
+FROM node:16.19.0-alpine
 
 COPY .serverlessrc /home/node/.serverlessrc
 RUN mkdir /app /serverless /home/node/.config /home/node/.serverless


### PR DESCRIPTION
Update Node version to 16.19.0 to support the use of Bicep for Azure Development