### PR TITLE
chore: more flexible regex for version switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ determine_serverless_image() {
         NODE_VERSION=$(<"$NVM_RC")
 
         if [[ $NODE_VERSION =~ ^v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?$ ]]; then
-            echo "aligent/serverless:node${BASH_REMATCH[1]}"
+            echo "aligent/serverless:latest-node${BASH_REMATCH[1]}"
             return 0
         fi
     fi

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ determine_serverless_image() {
     if [ -s "$NVM_RC" ]; then 
         NODE_VERSION=$(<"$NVM_RC")
 
-        if [[ $NODE_VERSION =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        if [[ $NODE_VERSION =~ ^v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?$ ]]; then
             echo "aligent/serverless:node${BASH_REMATCH[1]}"
             return 0
         fi


### PR DESCRIPTION
This will allow matching  node versions with/without a preceding v character and with/without minor/patch versions.

Currently a valid `.nvmrc` spec like `v16.11` does not match the regex.