### PR TITLE
Switch default image to node 16

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # Extract the node version of image that is being built e.g. 3.30.6-node18 builds an image based on node:18-alpine
-# For the latest tag we default to node 18
+# For the latest tag we default to node 16
 if [[ $DOCKER_TAG =~ ^[0-9a-zA-Z.]+-node([0-9.]+)$ ]]; then 
   VERSION=${BASH_REMATCH[1]}
 elif [[ $DOCKER_TAG == 'latest' ]]; then
-  VERSION='18'
+  VERSION='16'
 else
   echo 'Unsupported tag.'
   exit 1;


### PR DESCRIPTION
Most pipelines are not defining the version of the serverless image to use, so they will fail due to being upgraded to node 18. For now we will set the latest tag to use node 16. 

There will still be some updates required to the individual repos as the `package.json` defines ~16.11.0 in the engines section however it will not require an update to node 16 or changing of the pipelines definition. 