### PR TITLE
fix: update bash alias to remove double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ determine_serverless_image() {
     return 0
 }
 
-alias node-run="docker run --rm -it --volume ~/.aws:/home/node/.aws --volume ~/.azure:/home/node/.azure --volume ~/.npm:/home/node/.npm --volume \"$PWD:/app\" $(determine_serverless_image)"
+alias node-run='docker run --rm -it --volume ~/.aws:/home/node/.aws --volume ~/.azure:/home/node/.azure --volume ~/.npm:/home/node/.npm --volume $PWD:/app $(determine_serverless_image)'
 ```


### PR DESCRIPTION
Double quotes will resolve at initialization time, rather than run time. Single quotes resolve at runtime.

https://stackoverflow.com/questions/16232931/bash-cached-command-result-in-alias