### PR TITLE
Version upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ RUN chown node:node /app /serverless /home/node/.config /home/node/.serverless /
 
 RUN apk update && \
     apk add \
-      sudo python3 py3-pip bash shadow make g++ groff less git openssh &&  \
-    pip3 --no-cache-dir install --upgrade awscli && \
+      sudo bash shadow make g++ groff less git openssh awscli \
     rm -rf /var/cache/apk/*
 
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_TAG
+ARG NODE_TAG=alpine # default value
 FROM node:${NODE_TAG}
 
 COPY .serverlessrc /home/node/.serverlessrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir /app /serverless /home/node/.config /home/node/.serverless
 RUN chown node:node /app /serverless /home/node/.config /home/node/.serverless /home/node/.serverlessrc
 
 RUN apk update && \
-    apk add \
-      sudo bash shadow make g++ groff less git openssh awscli \
-    rm -rf /var/cache/apk/*
+    apk add sudo bash shadow make g++ groff less git openssh aws-cli
+
+RUN rm -rf /var/cache/apk/*
 
 USER node
 WORKDIR /serverless


### PR DESCRIPTION
Pushing through an update to fix an issue when using the latest version of node alpine images. Python virtual environments (venv) conflicted with the AWS CLI installation. As the awscli is available as an alpine package I've removed the python installation method in favour of standard apk add.

Also added a default value for the NODE_TAG build arg. This should never be used but it's there to follow best practice. 